### PR TITLE
refactor: use named export and add CreateHistoryFunction type

### DIFF
--- a/__tests__/history/hash.spec.ts
+++ b/__tests__/history/hash.spec.ts
@@ -1,6 +1,6 @@
 import { JSDOM } from 'jsdom'
-import createWebHashHistory from '../../src/history/hash'
-import createWebHistory from '../../src/history/html5'
+import { createWebHashHistory } from '../../src/history/hash'
+import { createWebHistory } from '../../src/history/html5'
 import { createDom } from '../utils'
 
 jest.mock('../../src/history/html5')

--- a/__tests__/history/html5.spec.ts
+++ b/__tests__/history/html5.spec.ts
@@ -1,5 +1,5 @@
 import { JSDOM } from 'jsdom'
-import createWebHistory from '../../src/history/html5'
+import { createWebHistory } from '../../src/history/html5'
 import { createDom } from '../utils'
 
 // override the value of isBrowser because the variable is created before JSDOM

--- a/__tests__/history/memory.spec.ts
+++ b/__tests__/history/memory.spec.ts
@@ -1,4 +1,4 @@
-import createMemoryHistory from '../../src/history/memory'
+import { createMemoryHistory } from '../../src/history/memory'
 import {
   START,
   HistoryLocationNormalized,

--- a/src/history/common.ts
+++ b/src/history/common.ts
@@ -59,6 +59,8 @@ export const START: HistoryLocationNormalized = {
 
 export type ValueContainer<T> = { value: T }
 
+export type CreateHistoryFunction = (base?: string) => RouterHistory
+
 /**
  * Interface implemented by History implementations that can be passed to the
  * router as {@link Router.history}

--- a/src/history/hash.ts
+++ b/src/history/hash.ts
@@ -1,7 +1,6 @@
-import { RouterHistory, normalizeBase } from './common'
-import createWebHistory from './html5'
+import { normalizeBase, CreateHistoryFunction } from './common'
+import { createWebHistory } from './html5'
 
-export default function createWebHashHistory(base?: string): RouterHistory {
+export const createWebHashHistory: CreateHistoryFunction = (base?: string) =>
   // Make sure this implementation is fine in terms of encoding, specially for IE11
-  return createWebHistory(location.host ? normalizeBase(base) + '/#' : '#')
-}
+  createWebHistory(location.host ? normalizeBase(base) + '/#' : '#')

--- a/src/history/html5.ts
+++ b/src/history/html5.ts
@@ -9,6 +9,7 @@ import {
   RawHistoryLocation,
   ValueContainer,
   normalizeBase,
+  CreateHistoryFunction,
 } from './common'
 import {
   computeScrollPosition,
@@ -265,7 +266,7 @@ function useHistoryStateNavigation(base: string) {
   }
 }
 
-export default function createWebHistory(base?: string): RouterHistory {
+export const createWebHistory: CreateHistoryFunction = (base?: string) => {
   base = normalizeBase(base)
 
   const historyNavigation = useHistoryStateNavigation(base)

--- a/src/history/memory.ts
+++ b/src/history/memory.ts
@@ -8,6 +8,7 @@ import {
   NavigationType,
   NavigationDirection,
   NavigationInformation,
+  CreateHistoryFunction,
 } from './common'
 
 /**
@@ -16,7 +17,9 @@ import {
  * @param base - Base applied to all urls, defaults to '/'
  * @returns a history object that can be passed to the router constructor
  */
-export default function createMemoryHistory(base: string = ''): RouterHistory {
+export const createMemoryHistory: CreateHistoryFunction = (
+  base: string = ''
+) => {
   let listeners: NavigationCallback[] = []
   // TODO: make sure this is right as the first location is nowhere so maybe this should be empty instead
   let queue: HistoryLocationNormalized[] = [START]

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,3 @@
-import createWebHistory from './history/html5'
-import createMemoryHistory from './history/memory'
-import createWebHashHistory from './history/hash'
-
 export {
   LocationQuery,
   parseQuery,
@@ -11,6 +7,9 @@ export {
 } from './query'
 
 export { RouterHistory } from './history/common'
+export { createWebHashHistory } from './history/hash'
+export { createWebHistory } from './history/html5'
+export { createMemoryHistory } from './history/memory'
 
 export { RouteRecord, RouteRecordNormalized } from './matcher/types'
 
@@ -40,7 +39,5 @@ export { NavigationFailureType, NavigationFailure } from './errors'
 export { onBeforeRouteLeave, onBeforeRouteUpdate } from './navigationGuards'
 export { RouterLink, useLink } from './RouterLink'
 export { RouterView } from './RouterView'
-
-export { createWebHistory, createMemoryHistory, createWebHashHistory }
 
 export * from './useApi'


### PR DESCRIPTION
Two changes:

### 1. Use named export

Remove `export default` in `history/xxx` dir

### 2. Add `CreateHistoryFunction` type

Just like [CreateAppFunction](https://github.com/vuejs/vue-next/blob/ded92f93b423cda28a40746c1f5fa9bcba56e80d/packages/runtime-core/src/apiCreateApp.ts#L103-L106) in vue-next