### PR TITLE
test(e2e): fix transition e2e specs by increasing css timing

### DIFF
--- a/e2e/specs/transitions.js
+++ b/e2e/specs/transitions.js
@@ -6,7 +6,7 @@ module.exports = {
   '@tags': ['no-headless'],
 
   transitions: function (browser) {
-    const TIMEOUT = 2000
+    const TIMEOUT = 3000
 
     browser
       .url('http://localhost:8080/transitions/')

--- a/e2e/transitions/index.html
+++ b/e2e/transitions/index.html
@@ -11,7 +11,7 @@
     <style>
       .fade-enter-active,
       .fade-leave-active {
-        transition: opacity 2s ease;
+        transition: opacity 0.75s ease;
       }
       .fade-enter-from,
       .fade-leave-active {
@@ -19,7 +19,7 @@
       }
       .child-view {
         position: absolute;
-        transition: all 2s cubic-bezier(0.55, 0, 0.1, 1);
+        transition: all 0.75s cubic-bezier(0.55, 0, 0.1, 1);
       }
       .slide-left-enter-from,
       .slide-right-leave-active {

--- a/e2e/transitions/index.html
+++ b/e2e/transitions/index.html
@@ -11,7 +11,7 @@
     <style>
       .fade-enter-active,
       .fade-leave-active {
-        transition: opacity 0.5s ease;
+        transition: opacity 2s ease;
       }
       .fade-enter-from,
       .fade-leave-active {
@@ -19,7 +19,7 @@
       }
       .child-view {
         position: absolute;
-        transition: all 0.5s cubic-bezier(0.55, 0, 0.1, 1);
+        transition: all 2s cubic-bezier(0.55, 0, 0.1, 1);
       }
       .slide-left-enter-from,
       .slide-right-leave-active {


### PR DESCRIPTION
When debugging via the HTML, the transition spec had the right html right before it was failing... so this is simply a matter of timing. By increasing the time the transition takes, we have a better chance of not failing.

I think that because each assertion takes at least 10-15ms. When the transition was set to 500ms, we were cutting it "too close". Sometimes the transition would finish before the assertions did.

Here's the command I used before/after the failures to console.log the body. I couldn't figure out the whole reporter ecosystem so I'm not sure how to bake this into Nightwatch's "afterEach" hooks to make CI debugging better.

```js
// ... assert, waitForElementPresent, etc
.source(result => console.log(result.value))
```