### PR TITLE
feat: explicit injection symbols in dev mode

### DIFF
--- a/src/injectionSymbols.ts
+++ b/src/injectionSymbols.ts
@@ -8,18 +8,24 @@ export const hasSymbol =
 
 export const PolySymbol = (name: string) =>
   // vr = vue router
-  hasSymbol ? Symbol(name) : `_vr_` + name
+  hasSymbol
+    ? Symbol(__DEV__ ? '[vue-router]: ' + name : name)
+    : (__DEV__ ? '[vue-router]: ' : '_vr_') + name
 
 // rvlm = Router View Location Matched
-export const matchedRouteKey = PolySymbol('rvlm') as InjectionKey<
-  ComputedRef<RouteRecordNormalized | undefined>
->
+export const matchedRouteKey = PolySymbol(
+  __DEV__ ? 'router view location matched' : 'rvlm'
+) as InjectionKey<ComputedRef<RouteRecordNormalized | undefined>>
 // rvd = Router View Depth
-export const viewDepthKey = PolySymbol('rvd') as InjectionKey<number>
+export const viewDepthKey = PolySymbol(
+  __DEV__ ? 'router view depth' : 'rvd'
+) as InjectionKey<number>
 
 // r = router
-export const routerKey = PolySymbol('r') as InjectionKey<Router>
-// rt = route location
-export const routeLocationKey = PolySymbol('rl') as InjectionKey<
-  RouteLocationNormalizedLoaded
+export const routerKey = PolySymbol(__DEV__ ? 'router' : 'r') as InjectionKey<
+  Router
 >
+// rt = route location
+export const routeLocationKey = PolySymbol(
+  __DEV__ ? 'route location' : 'rl'
+) as InjectionKey<RouteLocationNormalizedLoaded>


### PR DESCRIPTION
Instead of Vue throwing `injection "Symbol(r)" not found.` when the router is not provided, it now throws a more explicit error in DEV mode:

    injection "Symbol([view router]: router)" not found.

I think it gives a better hint to developers when encountering this issue.