### PR TITLE
fix: typo in <router-view> deprecation warning

### DIFF
--- a/src/RouterView.ts
+++ b/src/RouterView.ts
@@ -125,7 +125,7 @@ function warnDeprecatedUsage() {
     warn(
       `<router-view> can no longer be used directly inside <transition> or <keep-alive>.\n` +
         `Use slot props instead:\n\n` +
-        `<router-view v-slot="{ Component }>\n` +
+        `<router-view v-slot="{ Component }">\n` +
         `  <${comp}>\n` +
         `    <component :is="Component" />\n` +
         `  </${comp}>\n` +


### PR DESCRIPTION
This adds a missing double quote in the deprecation warning using <router-view> inside <transition> & <keep-alive>.