### PR TITLE
repro(types): components with required props

### DIFF
--- a/e2e/modal/index.ts
+++ b/e2e/modal/index.ts
@@ -1,6 +1,14 @@
 import { createRouter, createWebHistory, useRoute } from '../../src'
 import { RouteComponent, RouteLocationNormalizedLoaded } from '../../src/types'
-import { createApp, readonly, ref, watchEffect, computed, toRefs } from 'vue'
+import {
+  createApp,
+  readonly,
+  ref,
+  watchEffect,
+  computed,
+  toRefs,
+  defineComponent,
+} from 'vue'
 
 const users = readonly([
   { name: 'John' },
@@ -94,7 +102,7 @@ const About: RouteComponent = {
   },
 }
 
-const UserDetails: RouteComponent = {
+const UserDetails = defineComponent({
   template: `<div>
     <h1>User #{{ id }}</h1>
     <p>
@@ -102,9 +110,14 @@ const UserDetails: RouteComponent = {
     </p>
     <router-link to="/">Back home</router-link>
   </div>`,
-  props: ['id'],
+  props: {
+    id: {
+      type: String,
+      required: true,
+    },
+  },
   data: () => ({ users }),
-}
+})
 
 const webHistory = createWebHistory('/' + __dirname)
 const router = createRouter({

--- a/test-dts/createRouter.test-d.ts
+++ b/test-dts/createRouter.test-d.ts
@@ -7,11 +7,18 @@ import {
 } from './index'
 import { createApp, defineComponent } from 'vue'
 
-const component = defineComponent({})
+const component = defineComponent({
+  props: {
+    userId: {
+      type: String,
+      required: true,
+    },
+  },
+})
 
 const router = createRouter({
   history: createWebHistory(),
-  routes: [{ path: '/', component }],
+  routes: [{ path: '/', component, props: true }],
   parseQuery: search => ({}),
   stringifyQuery: query => '',
   strict: true,


### PR DESCRIPTION
This is a repro to illustrate a compilation error with components using required props.

With a route like `{ path: '/', component, props: true }`, if the component has a required prop, then the TS compilation fails with:
```typescript
TS2322: Type 'ComponentPublicInstanceConstructor<ComponentPublicInstance<{ id: string; } & {}, {}, { users: readonly { name: string; }[]; }, {}, {}, Record<string, any>, VNodeProps, ComponentOptionsBase<{ id: string; } & {}, unknown, { users: readonly { name: string; }[]; }, {}, ... 4 more ..., string>>> & ComponentOptionsBase<.....' is not assignable to type 'RawRouteComponent'.
  Type 'ComponentPublicInstanceConstructor<ComponentPublicInstance<{ id: string; } & {}, {}, { users: readonly { name: string; }[]; }, {}, {}, Record<string, any>, VNodeProps, ComponentOptionsBase<{ id: string; } & {}, unknown, { users: readonly { name: string; }[]; }, {}, ... 4 more ..., string>>> & ComponentOptionsBase<.....' is not assignable to type 'FunctionalComponent<any, Record<string, any>>'.
    Type 'ComponentPublicInstanceConstructor<ComponentPublicInstance<{ id: string; } & {}, {}, { users: readonly { name: string; }[]; }, {}, {}, Record<string, any>, VNodeProps, ComponentOptionsBase<{ id: string; } & {}, unknown, { users: readonly { name: string; }[]; }, {}, ... 4 more ..., string>>> & ComponentOptionsBase<.....' provides no match for the signature '(props: any, ctx: SetupContext<Record<string, any>>): any'.
```

Update: I hoped to reproduce with a tsd test, but it does not fail, so there might be something fishy with the tsd setup?