### PR TITLE
chore: add (err) after catch, search with 'catch {' and confirm again with search '} catch'

### DIFF
--- a/src/scrollBehavior.ts
+++ b/src/scrollBehavior.ts
@@ -113,7 +113,7 @@ export function scrollToPosition(position: ScrollPosition): void {
             // return to avoid other warnings
             return
           }
-        } catch {
+        } catch (err) {
           warn(
             `The selector "${position.el}" is invalid. If you are using an id selector, make sure to escape it. You can find more information about escaping characters in selectors at https://mathiasbynens.be/notes/css-escapes or use CSS.escape (https://developer.mozilla.org/en-US/docs/Web/API/CSS/escape).`
           )


### PR DESCRIPTION
closes #382 

chore: add (err) after catch, search with 'catch {' and confirm again with search '} catch'

![图片](https://user-images.githubusercontent.com/31165554/88353424-f739d000-cd8f-11ea-944a-f6b40e8e4b64.png)

