### PR TITLE
Allow defining properties in `meta`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ export {
 } from './matcher/pathParserRanker'
 
 export {
+  RouteMeta,
   _RouteLocationBase,
   _RouteRecordBase,
   RouteLocationRaw,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -121,7 +121,7 @@ export interface _RouteLocationBase {
   /**
    * Merged `meta` properties from all of the matched route records.
    */
-  meta: Record<string | number | symbol, any>
+  meta: RouteMeta
 }
 
 // matched contains resolved components
@@ -216,8 +216,10 @@ export interface _RouteRecordBase extends PathParserOptions {
   /**
    * Arbitrary data attached to the record.
    */
-  meta?: Record<string | number | symbol, any>
+  meta?: RouteMeta
 }
+
+export interface RouteMeta extends Record<string | number | symbol, any> {}
 
 export type RouteRecordRedirectOption =
   | RouteLocationRaw

--- a/test-dts/meta.test-d.ts
+++ b/test-dts/meta.test-d.ts
@@ -1,0 +1,43 @@
+import { createRouter, createWebHistory, expectType } from './index'
+import { createApp, defineComponent } from 'vue'
+
+const component = defineComponent({})
+
+declare module './index' {
+  interface RouteMeta {
+    requiresAuth?: boolean
+    nested: { foo: string }
+  }
+}
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes: [
+    {
+      path: '/',
+      component,
+      meta: {
+        requiresAuth: true,
+        lol: true,
+        nested: {
+          foo: 'bar',
+        },
+      },
+    },
+    {
+      path: '/foo',
+      // @ts-ignore
+      component,
+      // @ts-expect-error
+      meta: {},
+    },
+  ],
+})
+
+router.beforeEach(to => {
+  expectType<{ requiresAuth?: Boolean; nested: { foo: string } }>(to.meta)
+  if (to.meta.nested.foo == 'foo' || to.meta.lol) return false
+})
+
+const app = createApp({})
+app.use(router)


### PR DESCRIPTION
Ref https://github.com/vuejs/vue-router/issues/3183

Allow extending `meta` in TS:

```ts
declare module 'vue-router' {
  interface RouteMeta {
    requiresAuth?: boolean
    nested: { foo: string }
  }
}

export const router = createRouter({
  routes: [
    // error because `nested` is required
    { path: '/', component: Home, meta: {}
    // No Error because `meta` can be omitted
    { path: '/', component: Home }
  ]
})
```

I don't know if there is a way of creating an error on the last one without going into generics since it involves making the `meta` field conditionally required