### PR TITLE
fix(types): extend @vue/runtime-core module

### DIFF
--- a/src/globalExtensions.ts
+++ b/src/globalExtensions.ts
@@ -5,7 +5,7 @@ import {
 } from './types'
 import { Router } from './router'
 
-declare module 'vue' {
+declare module '@vue/runtime-core' {
   export interface ComponentCustomOptions {
     /**
      * Guard called when the router is navigating to the route that is rendering


### PR DESCRIPTION
closes #472

---

`declare module 'vue'` seems only to work if there is no other additional plugin