### PR TITLE
fix(router): allow `options.routes` is not provided

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -329,6 +329,8 @@ export interface Router {
  * @param options - {@link RouterOptions}
  */
 export function createRouter(options: RouterOptions): Router {
+  options = assign({ routes: [] }, options)
+
   const matcher = createRouterMatcher(options.routes, options)
   let parseQuery = options.parseQuery || originalParseQuery
   let stringifyQuery = options.stringifyQuery || originalStringifyQuery


### PR DESCRIPTION
Ref
https://github.com/vuejs/vue-router/blob/ccbd917458e73a4eeff9158674893b16de7f79c1/src/index.js#L47

