### PR TITLE
refactor(matcher): add error message for v3 catchall

### DIFF
--- a/__tests__/matcher/pathParser.spec.ts
+++ b/__tests__/matcher/pathParser.spec.ts
@@ -13,6 +13,16 @@ describe('Path parser', () => {
       expect(tokenizePath('')).toEqual([[]])
     })
 
+    it('v3 catchAll', () => {
+      expect(() => tokenizePath('*')).toThrowError(
+        `Catch all routes (/*) must now be defined using a parameter with a custom regex: /:catchAll(.*)`
+      )
+    })
+
+    it('not start with /', () => {
+      expect(() => tokenizePath('a')).toThrowError(`Route "a" should be "/a".`)
+    })
+
     it('escapes :', () => {
       expect(tokenizePath('/\\:')).toEqual([
         [{ type: TokenType.Static, value: ':' }],

--- a/src/matcher/pathTokenizer.ts
+++ b/src/matcher/pathTokenizer.ts
@@ -46,6 +46,11 @@ const VALID_PARAM_RE = /[a-zA-Z0-9_]/
 export function tokenizePath(path: string): Array<Token[]> {
   if (!path) return [[]]
   if (path === '/') return [[ROOT_TOKEN]]
+  // v3 catchAll must be renew
+  if (/^\/?\*/.test(path))
+    throw new Error(
+      `Catch all routes (/*) must now be defined using a parameter with a custom regex: /:catchAll(.*)`
+    )
   // remove the leading slash
   if (!path.startsWith('/'))
     throw new Error(`Route "${path}" should be "/${path}".`)


### PR DESCRIPTION
Got an error `Route "*" should be "/*".` when I set `path: '*'`.
However it still doesn't work (I didn't notice new catchall rule).

So added new error message for catchall.
