### PR TITLE
docs: add `$` in front of `route`

### DIFF
--- a/docs/guide/advanced/transitions.md
+++ b/docs/guide/advanced/transitions.md
@@ -34,7 +34,7 @@ const routes = [
 ```html
 <router-view v-slot="{ Component, route }">
   <!-- Use any custom transition and fallback to `fade` -->
-  <transition :name="route.meta.transition || 'fade'">
+  <transition :name="$route.meta.transition || 'fade'">
     <component :is="Component" />
   </transition>
 </router-view>


### PR DESCRIPTION
Using regular `route` does not work within the template.