### PR TITLE
docs: improve scroll-behavior.md (#522) [skip ci]

### DIFF
--- a/docs/guide/advanced/scroll-behavior.md
+++ b/docs/guide/advanced/scroll-behavior.md
@@ -35,10 +35,10 @@ You can also pass a CSS selector or a DOM element via `el`. In that scenario, `t
 const router = createRouter({
   scrollBehavior (to, from, savedPosition) {
     // always scroll 10px above the element #main
-    el: '#main',
+    // el: '#main'
     // could also be
     // el: document.getElementById('main'),
-    return { top: -10 }
+    return { el: '#main',  top: -10 }
   }
 })
 ```


### PR DESCRIPTION
fixing the syntax in scroll behavior function, the `el: '#main'` should be in a comment and the element **el** should be in the returned object.