### PR TITLE
refactor: add __PURE__ to improve tree-shaking

### DIFF
--- a/src/RouterLink.ts
+++ b/src/RouterLink.ts
@@ -125,7 +125,7 @@ export function useLink(props: UseLinkOptions) {
   }
 }
 
-export const RouterLinkImpl = defineComponent({
+export const RouterLinkImpl = /*#__PURE__*/ defineComponent({
   name: 'RouterLink',
   props: {
     to: {
@@ -259,7 +259,7 @@ function getOriginalPath(record: RouteRecord | undefined): string {
  * @param globalClass
  * @param defaultClass
  */
-let getLinkClass = (
+const getLinkClass = (
   propClass: string | undefined,
   globalClass: string | undefined,
   defaultClass: string

--- a/src/RouterView.ts
+++ b/src/RouterView.ts
@@ -33,7 +33,7 @@ export interface RouterViewProps {
   route?: RouteLocationNormalized
 }
 
-export const RouterViewImpl = defineComponent({
+export const RouterViewImpl = /*#__PURE__*/ defineComponent({
   name: 'RouterView',
   props: {
     name: {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -20,7 +20,7 @@ export const enum ErrorTypes {
   NAVIGATION_DUPLICATED = 16,
 }
 
-const NavigationFailureSymbol = PolySymbol(
+const NavigationFailureSymbol = /*#__PURE__*/ PolySymbol(
   __DEV__ ? 'navigation failure' : 'nf'
 )
 

--- a/src/injectionSymbols.ts
+++ b/src/injectionSymbols.ts
@@ -13,19 +13,19 @@ export const PolySymbol = (name: string) =>
     : (__DEV__ ? '[vue-router]: ' : '_vr_') + name
 
 // rvlm = Router View Location Matched
-export const matchedRouteKey = PolySymbol(
+export const matchedRouteKey = /*#__PURE__*/ PolySymbol(
   __DEV__ ? 'router view location matched' : 'rvlm'
 ) as InjectionKey<ComputedRef<RouteRecordNormalized | undefined>>
 // rvd = Router View Depth
-export const viewDepthKey = PolySymbol(
+export const viewDepthKey = /*#__PURE__*/ PolySymbol(
   __DEV__ ? 'router view depth' : 'rvd'
 ) as InjectionKey<number>
 
 // r = router
-export const routerKey = PolySymbol(__DEV__ ? 'router' : 'r') as InjectionKey<
-  Router
->
+export const routerKey = /*#__PURE__*/ PolySymbol(
+  __DEV__ ? 'router' : 'r'
+) as InjectionKey<Router>
 // rt = route location
-export const routeLocationKey = PolySymbol(
+export const routeLocationKey = /*#__PURE__*/ PolySymbol(
   __DEV__ ? 'route location' : 'rl'
 ) as InjectionKey<RouteLocationNormalizedLoaded>


### PR DESCRIPTION
There are some global variables that are not tree-shaked even we didn't use them.

Example here: https://github.com/antfu/vue-router-next-tree-shaking-test (bundle file under `/output`)

---

This PR adds `/*#__PURE__*/` for some global variables to improve the three-shaking.

However, TypeScript's enums still not be shook. Maybe we should switch to `const enums`. But as it alters the behavior, it's not included in this PR. (otherwise, we might need https://github.com/microsoft/TypeScript/issues/27604)

## Export Size Report

```bash
export-size . --bundler=rollup
```

### Before this PR

```
export-size  v0.3.2
rollup       v2.31.0
terser       v5.3.5

vue-router v4.0.0-beta.13

┌───────────────────────┬──────────┐
│ export                │ min+gzip │
│                       │          │
│ createRouter          │ 10.34 KB │
│ createRouterMatcher   │  5.43 KB │
│ createWebHashHistory  │  3.56 KB │
│ createWebHistory      │  3.46 KB │
│ stringifyQuery        │  2.45 KB │
│ createMemoryHistory   │  2.44 KB │
│ parseQuery            │  2.29 KB │
│ onBeforeRouteUpdate   │  2.25 KB │
│ onBeforeRouteLeave    │  2.25 KB │
│ START_LOCATION        │  2.17 KB │
│ isNavigationFailure   │  2.13 KB │
│ useRoute              │  2.11 KB │
│ useRouter             │  2.11 KB │
│ RouterLink            │   2.1 KB │
│ RouterView            │   2.1 KB │
│ NavigationFailureType │   2.1 KB │
│ useLink               │   2.1 KB │
└───────────────────────┴──────────┘
```

### This PR

```
export-size  v0.3.2
rollup       v2.31.0
terser       v5.3.5

vue-router v4.0.0-beta.13

┌───────────────────────┬──────────┐
│ export                │ min+gzip │
│                       │          │
│ createRouter          │ 10.34 KB │
│ createRouterMatcher   │  3.98 KB │
│ createWebHashHistory  │  2.04 KB │
│ createWebHistory      │  1.93 KB │
│ RouterLink            │  1.47 KB │
│ RouterView            │  1.21 KB │
│ useLink               │  1.16 KB │
│ stringifyQuery        │    821 B │
│ createMemoryHistory   │    816 B │
│ parseQuery            │    740 B │
│ onBeforeRouteUpdate   │    722 B │
│ onBeforeRouteLeave    │    721 B │
│ START_LOCATION        │    522 B │
│ isNavigationFailure   │    486 B │
│ useRouter             │    463 B │
│ useRoute              │    462 B │
│ NavigationFailureType │    430 B │
└───────────────────────┴──────────┘
```