### PR TITLE
fix(devtools): use assign instead of spread operator

### DIFF
--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -15,18 +15,18 @@ import { RouteRecordMatcher } from './matcher/pathMatcher'
 import { PathParser } from './matcher/pathParserRanker'
 import { Router } from './router'
 import { RouteLocationNormalized } from './types'
+import { assign, omit } from './utils'
 
 function formatRouteLocation(
   routeLocation: RouteLocationNormalized,
   tooltip?: string
 ) {
-  const copy = {
-    ...routeLocation,
+  const copy = assign({}, routeLocation, {
     // remove variables that can contain vue instances
-    matched: routeLocation.matched.map(
-      ({ instances, children, aliasOf, ...rest }) => rest
+    matched: routeLocation.matched.map(matched =>
+      omit(matched, ['instances', 'children', 'aliasOf'])
     ),
-  }
+  })
 
   return {
     _custom: {

--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -15,7 +15,7 @@ import { RouteRecordMatcher } from './matcher/pathMatcher'
 import { PathParser } from './matcher/pathParserRanker'
 import { Router } from './router'
 import { RouteLocationNormalized } from './types'
-import { assign, omit } from './utils'
+import { assign } from './utils'
 
 function formatRouteLocation(
   routeLocation: RouteLocationNormalized,
@@ -471,4 +471,18 @@ function isRouteMatching(route: RouteRecordMatcher, filter: string): boolean {
     return true
 
   return route.children.some(child => isRouteMatching(child, filter))
+}
+
+function omit<T extends object, K extends [...(keyof T)[]]>(obj: T, keys: K) {
+  const ret = {} as {
+    [K2 in Exclude<keyof T, K[number]>]: T[K2]
+  }
+
+  for (let key in obj) {
+    if (!keys.includes(key as any)) {
+      // @ts-ignore
+      ret[key] = obj[key]
+    }
+  }
+  return ret
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -24,20 +24,3 @@ export function applyToParams(
 }
 
 export let noop = () => {}
-
-export const omit = <T extends Record<string, any>>(
-  object: T,
-  paths: Array<keyof T>
-) => {
-  const result: Record<string, any> = {}
-  for (let key in object) {
-    if (
-      paths.indexOf(key) >= 0 ||
-      !Object.prototype.hasOwnProperty.call(object, key)
-    ) {
-      continue
-    }
-    result[key] = object[key]
-  }
-  return result
-}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -24,3 +24,20 @@ export function applyToParams(
 }
 
 export let noop = () => {}
+
+export const omit = <T extends Record<string, any>>(
+  object: T,
+  paths: Array<keyof T>
+) => {
+  const result: Record<string, any> = {}
+  for (let key in object) {
+    if (
+      paths.indexOf(key) >= 0 ||
+      !Object.prototype.hasOwnProperty.call(object, key)
+    ) {
+      continue
+    }
+    result[key] = object[key]
+  }
+  return result
+}


### PR DESCRIPTION
Fix #670 

1. use assign from utils.
2. add omit method to omit keys in object, like rest operator do.