### PR TITLE
fix(matcher): clear customRe after consuming buffer

### DIFF
--- a/__tests__/matcher/pathParser.spec.ts
+++ b/__tests__/matcher/pathParser.spec.ts
@@ -147,6 +147,29 @@ describe('Path parser', () => {
       ])
     })
 
+    it('param custom re followed by param without regex', () => {
+      expect(tokenizePath('/:one(\\d+)/:two')).toEqual([
+        [
+          {
+            type: TokenType.Param,
+            value: 'one',
+            regexp: '\\d+',
+            repeatable: false,
+            optional: false,
+          },
+        ],
+        [
+          {
+            type: TokenType.Param,
+            value: 'two',
+            regexp: '',
+            repeatable: false,
+            optional: false,
+          },
+        ],
+      ])
+    })
+
     it('param custom re?', () => {
       expect(tokenizePath('/:id(\\d+)?')).toEqual([
         [

--- a/src/matcher/pathTokenizer.ts
+++ b/src/matcher/pathTokenizer.ts
@@ -147,7 +147,6 @@ export function tokenizePath(path: string): Array<Token[]> {
       case TokenizerState.Param:
         if (char === '(') {
           state = TokenizerState.ParamRegExp
-          customRe = ''
         } else if (VALID_PARAM_RE.test(char)) {
           addCharToBuffer()
         } else {
@@ -180,6 +179,7 @@ export function tokenizePath(path: string): Array<Token[]> {
         state = TokenizerState.Static
         // go back one character if we were not modifying
         if (char !== '*' && char !== '?' && char !== '+') i--
+        customRe = ''
         break
 
       default:


### PR DESCRIPTION
Clear customRe after consuming buffer to avoid re-use for subsequent parameters.

close #679