### PR TITLE
docs: typo

### DIFF
--- a/docs/guide/advanced/navigation-failures.md
+++ b/docs/guide/advanced/navigation-failures.md
@@ -71,7 +71,7 @@ All navigation failures expose `to` and `from` properties to reflect the current
 
 ```js
 // trying to access the admin page
-router.push('/admin').push(failure => {
+router.push('/admin').then(failure => {
   if (isNavigationFailure(failure, NavigationFailureType.redirected)) {
     failure.to.path // '/admin'
     failure.from.path // '/'


### PR DESCRIPTION
I think it's wrong here ：router.push('/admin').push(failure);
router.push return promise instance, push should be replaced with then.