### PR TITLE
docs: fix typo

### DIFF
--- a/docs/guide/advanced/scroll-behavior.md
+++ b/docs/guide/advanced/scroll-behavior.md
@@ -82,7 +82,7 @@ const router = createRouter({
   scrollBehavior(to, from, savedPosition) {
     if (to.hash) {
       return {
-        el: to.hash
+        el: to.hash,
         behavior: 'smooth',
       }
     }


### PR DESCRIPTION
Added a missing comma in the code example.