### PR TITLE
docs: improve 404 example

### DIFF
--- a/docs/guide/essentials/dynamic-matching.md
+++ b/docs/guide/essentials/dynamic-matching.md
@@ -93,9 +93,10 @@ In this specific scenario we are using a [custom regexp](/guide/essentials/route
 ```js
 this.$router.push({
   name: 'NotFound',
-  params: { pathMatch: this.$route.path.split('/') },
+  params: { pathMatch: this.$route.path.substring(1).split('/') },
 })
 ```
+Notice that we should remove the first slash (`/`) from the path to avoid the target URL starting with with 2 slashes.
 
 See more in the [repeated params](/guide/essentials/route-matching-syntax.md#repeatable-params) section.
 

--- a/docs/guide/essentials/dynamic-matching.md
+++ b/docs/guide/essentials/dynamic-matching.md
@@ -93,13 +93,13 @@ In this specific scenario we are using a [custom regexp](/guide/essentials/route
 ```js
 this.$router.push({
   name: 'NotFound',
+  // preserve current path and remove the first char to avoid the target URL starting with `//`
   params: { pathMatch: this.$route.path.substring(1).split('/') },
   // preserve existing query and hash if any
   query: this.$route.query,
   hash: this.$route.hash,
 })
 ```
-Notice that we should remove the first slash (`/`) from the path to avoid the target URL starting with 2 slashes.
 
 See more in the [repeated params](/guide/essentials/route-matching-syntax.md#repeatable-params) section.
 

--- a/docs/guide/essentials/dynamic-matching.md
+++ b/docs/guide/essentials/dynamic-matching.md
@@ -94,6 +94,9 @@ In this specific scenario we are using a [custom regexp](/guide/essentials/route
 this.$router.push({
   name: 'NotFound',
   params: { pathMatch: this.$route.path.substring(1).split('/') },
+  // preserve existing query and hash if any
+  query: this.$route.query,
+  hash: this.$route.hash,
 })
 ```
 Notice that we should remove the first slash (`/`) from the path to avoid the target URL starting with 2 slashes.

--- a/docs/guide/essentials/dynamic-matching.md
+++ b/docs/guide/essentials/dynamic-matching.md
@@ -96,7 +96,7 @@ this.$router.push({
   params: { pathMatch: this.$route.path.substring(1).split('/') },
 })
 ```
-Notice that we should remove the first slash (`/`) from the path to avoid the target URL starting with with 2 slashes.
+Notice that we should remove the first slash (`/`) from the path to avoid the target URL starting with 2 slashes.
 
 See more in the [repeated params](/guide/essentials/route-matching-syntax.md#repeatable-params) section.
 


### PR DESCRIPTION
The [code example in `pathMatch`](https://next.router.vuejs.org/guide/essentials/dynamic-matching.html#catch-all-404-not-found-route) results in the target URL starting with 2 slashes and gives the following error in the console.

```
this.$router.push({
  name: 'NotFound',
  params: { pathMatch: this.$route.path.split('/') },
})
```

![image](https://user-images.githubusercontent.com/6147968/107638257-9d3b2200-6c6f-11eb-85b9-e5b9d24310c0.png)

I suggest to remove the first slash from the `path` using `substring(1)` before breaking it to an array. 

```
this.$router.push({
  name: 'NotFound',
  params: { pathMatch: this.$route.path.substring(1).split('/') },
})
```

The issue can be reproduced here: https://jsfiddle.net/j4pqmvh8/

I've also included a short notice in the docs.