### PR TITLE
refactor: use console.error during lazy loading

### DIFF
--- a/src/navigationGuards.ts
+++ b/src/navigationGuards.ts
@@ -298,9 +298,7 @@ export function extractComponentsGuards(
           componentPromise = Promise.resolve(componentPromise as RouteComponent)
         } else {
           // display the error if any
-          componentPromise = componentPromise.catch(
-            __DEV__ ? err => err && warn(err) : console.error
-          )
+          componentPromise = componentPromise.catch(console.error)
         }
 
         guards.push(() =>


### PR DESCRIPTION
By using `console.error` even in the development environment, we will provide useful information such as the reference to the actual ES module that failed and the code line where it happened.

This is especially important if the errors happen in an imported package, no matter how deep it is.

See the comparison here:

- With the current implementation, which uses `warn` in dev and `console.error` in prod:

![image](https://user-images.githubusercontent.com/1077520/108272517-a0a04300-7172-11eb-94bc-31adbc68122d.png)

You can see that the stack trace is of no help at all.

- With `console.error` after the usual `warn`:

![image](https://user-images.githubusercontent.com/1077520/108272327-6171f200-7172-11eb-9c14-a9b2e439fd2b.png)

Now, the browser points me to the module that failed.

By the way, let me please celebrate the [almost All Lucky 7s](https://finalfantasy.fandom.com/wiki/All_Lucky_7s) PR 😆 