### PR TITLE
refactor: remove unused parameter in unmount

### DIFF
--- a/e2e/multi-app/index.ts
+++ b/e2e/multi-app/index.ts
@@ -127,6 +127,6 @@ looper.forEach((n, i) => {
 
   unmountBtn.addEventListener('click', () => {
     let app = apps[i]
-    app && app.unmount('#app-' + n)
+    app && app.unmount()
   })
 })

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "ts-node": "^9.1.1",
     "typescript": "^4.1.5",
     "vitepress": "^0.12.2",
-    "vue": "^3.0.5",
+    "vue": "^3.0.6",
     "vue-loader": "^16.1.2",
     "webpack": "^5.21.2",
     "webpack-bundle-analyzer": "^4.4.0",

--- a/src/router.ts
+++ b/src/router.ts
@@ -1131,7 +1131,7 @@ export function createRouter(options: RouterOptions): Router {
           started = false
           ready = false
         }
-        unmountApp.call(this, arguments)
+        unmountApp()
       }
 
       if ((__DEV__ || __FEATURE_PROD_DEVTOOLS__) && __BROWSER__) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1158,6 +1158,17 @@
     estree-walker "^2.0.1"
     source-map "^0.6.1"
 
+"@vue/compiler-core@3.0.6":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.0.6.tgz#265bbe0711a81ab4c1344f8294e22e2d08ca167d"
+  integrity sha512-O7QzQ39DskOoPpEDWRvKwDX7Py9UNT7SvLHvBdIfckGA3OsAEBdiAtuYQNcVmUDeBajm+08v5wyvHWBbWgkilQ==
+  dependencies:
+    "@babel/parser" "^7.12.0"
+    "@babel/types" "^7.12.0"
+    "@vue/shared" "3.0.6"
+    estree-walker "^2.0.1"
+    source-map "^0.6.1"
+
 "@vue/compiler-dom@3.0.5":
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.0.5.tgz#7885a13e6d18f64dde8ebceec052ed2c102696c2"
@@ -1165,6 +1176,14 @@
   dependencies:
     "@vue/compiler-core" "3.0.5"
     "@vue/shared" "3.0.5"
+
+"@vue/compiler-dom@3.0.6":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.0.6.tgz#f94c3959320a1252915bd02b943f96a7ee3fc951"
+  integrity sha512-q1wfHzYwvDRAhBlx+Qa+n3Bu5nHr1qL/j0UbpNlbQDwIlt9zpvmXUrUCL+i55Bh5lLKvSe+mNo0qlwNEApm+jA==
+  dependencies:
+    "@vue/compiler-core" "3.0.6"
+    "@vue/shared" "3.0.6"
 
 "@vue/compiler-sfc@^3.0.5":
   version "3.0.5"
@@ -1208,6 +1227,13 @@
   dependencies:
     "@vue/shared" "3.0.5"
 
+"@vue/reactivity@3.0.6":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@vue/reactivity/-/reactivity-3.0.6.tgz#7b16f3d5d04cc55028085fff0bb8475cc0e32991"
+  integrity sha512-hX8PnZayNMoljWSYrZW0OclQnRaMoHxvi5eeFVFPDr7+tzBeiftmmozKttxxCLoDxBWX1B4gNc237DIcYU63Lw==
+  dependencies:
+    "@vue/shared" "3.0.6"
+
 "@vue/runtime-core@3.0.5":
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/@vue/runtime-core/-/runtime-core-3.0.5.tgz#da6331d5f300d5794e9e0ebdc8a8bd72a9e19962"
@@ -1216,6 +1242,14 @@
     "@vue/reactivity" "3.0.5"
     "@vue/shared" "3.0.5"
 
+"@vue/runtime-core@3.0.6":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@vue/runtime-core/-/runtime-core-3.0.6.tgz#d16779b5664593f1d25be677fb1b1968024aa532"
+  integrity sha512-x6N38P0DeMyrHiAxCE/rACHTyydOzlg8IyUIPkSJ4rrSkuJnAtFKQicK6fm8NuD21dwdPr8KcZ4Cn4xaqL1JJg==
+  dependencies:
+    "@vue/reactivity" "3.0.6"
+    "@vue/shared" "3.0.6"
+
 "@vue/runtime-dom@3.0.5":
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/@vue/runtime-dom/-/runtime-dom-3.0.5.tgz#1ce2c9c449e26ab06963da0064096e882a7a8935"
@@ -1223,6 +1257,15 @@
   dependencies:
     "@vue/runtime-core" "3.0.5"
     "@vue/shared" "3.0.5"
+    csstype "^2.6.8"
+
+"@vue/runtime-dom@3.0.6":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@vue/runtime-dom/-/runtime-dom-3.0.6.tgz#e7d6c61913d871f1f020a9a81b558c8fcbeba8c6"
+  integrity sha512-Y6y4Tak9//VXB2mp2NVQxbwC4a5xsnJpotpo8yBAB3qB3L4v4HQLpqxSkwThRwI6Y6Z7dydX/sgfraqLBE8BWg==
+  dependencies:
+    "@vue/runtime-core" "3.0.6"
+    "@vue/shared" "3.0.6"
     csstype "^2.6.8"
 
 "@vue/server-renderer@^3.0.5":
@@ -1237,6 +1280,11 @@
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.0.5.tgz#c131d88bd6713cc4d93b3bb1372edb1983225ff0"
   integrity sha512-gYsNoGkWejBxNO6SNRjOh/xKeZ0H0V+TFzaPzODfBjkAIb0aQgBuixC1brandC/CDJy1wYPwSoYrXpvul7m6yw==
+
+"@vue/shared@3.0.6":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.0.6.tgz#d65576430fc4ad383dc7c829118798e5169178d4"
+  integrity sha512-c37C60HpelUZIx+SNZVEINSxkFzQYhIXFg5AynnIA4QDBmY4iSPoACfGSwSUTCTKImukPeCgY2oqRJVP3R1Mnw==
 
 "@vue/test-utils@^2.0.0-rc.1":
   version "2.0.0-rc.1"
@@ -9184,6 +9232,15 @@ vue@^3.0.5:
     "@vue/compiler-dom" "3.0.5"
     "@vue/runtime-dom" "3.0.5"
     "@vue/shared" "3.0.5"
+
+vue@^3.0.6:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/vue/-/vue-3.0.6.tgz#2c16ed4bb66f16d6c6f6eaa3b7d5835a76598049"
+  integrity sha512-fgjbe/+f1EsqG7ZbaFSnxdzQXF2DKoFCdJlPxZZJy9XMtyXS6SY8pGzLi8WYb4zmsPLHvTZz4bHW30kFDk7vfA==
+  dependencies:
+    "@vue/compiler-dom" "3.0.6"
+    "@vue/runtime-dom" "3.0.6"
+    "@vue/shared" "3.0.6"
 
 w3c-hr-time@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
### Version
4.0.4
vue@3.0.6

### Reproduction link
[https://v3.vuejs.org/api/application-api.html#unmount](https://v3.vuejs.org/api/application-api.html#unmount)




### Steps to reproduce
* git clone https://github.com/vuejs/vue-router-next.git
* cd vue-router-next
* yarn add vue@next
* yarn test


### What is expected?
All tests should pass

### What is actually happening?
```
src/router.ts:1134:31 - error TS2554: Expected 1 arguments, but got 2.

1134         unmountApp.call(this, arguments)
```

---
https://github.com/vuejs/vue-next/commit/18b0c9a011b7569deae433fbbdf123764db2eae8

<!-- generated by vue-issues. DO NOT REMOVE -->

Close #793 