### PR TITLE
docs: use correct imports in code example

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -34,6 +34,9 @@ Note how instead of using regular `a` tags, we use a custom component `router-li
 ## JavaScript
 
 ```js
+import { createApp } from "vue";
+import { createRouter, createWebHashHistory } from "vue-router";
+
 // 1. Define route components.
 // These can be imported from other files
 const Home = { template: '<div>Home</div>' }
@@ -50,14 +53,14 @@ const routes = [
 // 3. Create the router instance and pass the `routes` option
 // You can pass in additional options here, but let's
 // keep it simple for now.
-const router = VueRouter.createRouter({
+const router = createRouter({
   // 4. Provide the history implementation to use. We are using the hash history for simplicity here.
-  history: VueRouter.createWebHashHistory(),
+  history: createWebHashHistory(),
   routes, // short for `routes: routes`
 })
 
 // 5. Create and mount the root instance.
-const app = Vue.createApp({})
+const app = createApp({})
 // Make sure to _use_ the router instance to make the
 // whole app router-aware.
 app.use(router)


### PR DESCRIPTION
The code example didn't work since it suggested that vue and vue-router have a named export which is not the case. To make it easier for beginners, I've added the correct imports to the code example.