### PR TITLE
fix: do not allow invalid hazardous keys in query

### DIFF
--- a/__tests__/parseQuery.spec.ts
+++ b/__tests__/parseQuery.spec.ts
@@ -85,4 +85,15 @@ describe('parseQuery', () => {
 
     expect('decoding "%"').toHaveBeenWarnedTimes(1)
   })
+
+  it('keep prototype', () => {
+    const query = parseQuery('__proto__=1')
+    expect(query.__proto__).toEqual(Object.prototype)
+    expect(query.constructor).toEqual(Object)
+  })
+
+  it('keep build-in methods', () => {
+    const query = parseQuery('toString=1')
+    expect(query.toString).toEqual(Object.prototype.toString)
+  })
 })

--- a/__tests__/parseQuery.spec.ts
+++ b/__tests__/parseQuery.spec.ts
@@ -92,7 +92,7 @@ describe('parseQuery', () => {
     expect(query.constructor).toEqual(Object)
   })
 
-  it('keep build-in methods', () => {
+  it('ignores build-in methods', () => {
     const query = parseQuery('toString=1')
     expect(query.toString).toEqual(Object.prototype.toString)
   })

--- a/__tests__/parseQuery.spec.ts
+++ b/__tests__/parseQuery.spec.ts
@@ -86,7 +86,7 @@ describe('parseQuery', () => {
     expect('decoding "%"').toHaveBeenWarnedTimes(1)
   })
 
-  it('keep prototype', () => {
+  it('ignores __proto__', () => {
     const query = parseQuery('__proto__=1')
     expect(query.__proto__).toEqual(Object.prototype)
     expect(query.constructor).toEqual(Object)

--- a/src/query.ts
+++ b/src/query.ts
@@ -37,8 +37,7 @@ export type LocationQueryRaw = Record<
  * Do not allow invalid hazardous query keys
  */
 function isAllowedQueryKey(key: string): boolean {
-  const keysBlockList = ['__proto__', 'constructor', 'prototype']
-  return !keysBlockList.includes(key) && !Object.prototype.hasOwnProperty(key)
+  return !Object.prototype.hasOwnProperty(key)
 }
 
 /**

--- a/src/query.ts
+++ b/src/query.ts
@@ -34,13 +34,6 @@ export type LocationQueryRaw = Record<
 >
 
 /**
- * Do not allow invalid hazardous query keys
- */
-function isAllowedQueryKey(key: string): boolean {
-  return !Object.prototype.hasOwnProperty(key)
-}
-
-/**
  * Transforms a queryString into a {@link LocationQuery} object. Accept both, a
  * version with the leading `?` and without Should work as URLSearchParams
 
@@ -62,9 +55,12 @@ export function parseQuery(search: string): LocationQuery {
     // allow the = character
     let eqPos = searchParam.indexOf('=')
     let key = decode(eqPos < 0 ? searchParam : searchParam.slice(0, eqPos))
-    if (!isAllowedQueryKey(key)) {
+
+    // this ignores ?__proto__&toString
+    if (Object.prototype.hasOwnProperty(key)) {
       continue
     }
+
     let value = eqPos < 0 ? null : decode(searchParam.slice(eqPos + 1))
 
     if (key in query) {

--- a/src/query.ts
+++ b/src/query.ts
@@ -57,7 +57,6 @@ export function parseQuery(search: string): LocationQuery {
   if (search === '' || search === '?') return query
   const hasLeadingIM = search[0] === '?'
   const searchParams = (hasLeadingIM ? search.slice(1) : search).split('&')
-
   for (let i = 0; i < searchParams.length; ++i) {
     // pre decode the + into space
     const searchParam = searchParams[i].replace(PLUS_RE, ' ')


### PR DESCRIPTION
I drew attention to that when parsing the search query, it is possible to some extent manipulate the prototype of the returned object. I added a few checks so that at least partially prevent it. 