### PR TITLE
docs: fix RouteMeta typing example

### DIFF
--- a/docs/guide/advanced/meta.md
+++ b/docs/guide/advanced/meta.md
@@ -56,6 +56,8 @@ router.beforeEach((to, from) => {
 It is possible to type the meta field by extending the `RouteMeta` interface:
 
 ```ts
+import 'vue-router'
+
 declare module 'vue-router' {
   interface RouteMeta {
     // is optional


### PR DESCRIPTION
Without this change the example would have no exported members other than RouteMeta, a simple line of code such as:

```ts
import { createRouter } from 'vue-router'
```

Would throw the folloing error:

```
Module '"vue-router"' has no exported member 'createRouter'.
```