### PR TITLE
docs: RouterMeta typing example

### DIFF
--- a/docs/guide/advanced/meta.md
+++ b/docs/guide/advanced/meta.md
@@ -56,8 +56,8 @@ router.beforeEach((to, from) => {
 It is possible to type the meta field by extending the `RouteMeta` interface:
 
 ```ts
+// typings.d.ts
 import 'vue-router'
-
 declare module 'vue-router' {
   interface RouteMeta {
     // is optional

--- a/docs/guide/advanced/meta.md
+++ b/docs/guide/advanced/meta.md
@@ -56,8 +56,9 @@ router.beforeEach((to, from) => {
 It is possible to type the meta field by extending the `RouteMeta` interface:
 
 ```ts
-// typings.d.ts
+// typings.d.ts or router.ts
 import 'vue-router'
+
 declare module 'vue-router' {
   interface RouteMeta {
     // is optional

--- a/docs/zh/guide/advanced/meta.md
+++ b/docs/zh/guide/advanced/meta.md
@@ -56,7 +56,8 @@ router.beforeEach((to, from) => {
 可以通过扩展 `RouteMeta` 接口来输入 meta 字段：
 
 ```ts
-// typings.d.ts
+// typings.d.ts or router.ts
+
 import 'vue-router'
 declare module 'vue-router' {
   interface RouteMeta {

--- a/docs/zh/guide/advanced/meta.md
+++ b/docs/zh/guide/advanced/meta.md
@@ -56,6 +56,8 @@ router.beforeEach((to, from) => {
 可以通过扩展 `RouteMeta` 接口来输入 meta 字段：
 
 ```ts
+// typings.d.ts
+import 'vue-router'
 declare module 'vue-router' {
   interface RouteMeta {
     // 是可选的

--- a/docs/zh/guide/advanced/meta.md
+++ b/docs/zh/guide/advanced/meta.md
@@ -57,8 +57,8 @@ router.beforeEach((to, from) => {
 
 ```ts
 // typings.d.ts or router.ts
-
 import 'vue-router'
+
 declare module 'vue-router' {
   interface RouteMeta {
     // 是可选的

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -253,6 +253,8 @@ export interface _RouteRecordBase extends PathParserOptions {
  * @example
  *
  * ```ts
+ * // typings.d.ts
+ * import 'vue-router';
  * declare module 'vue-router' {
  *   interface RouteMeta {
  *     requiresAuth?: boolean

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -253,7 +253,8 @@ export interface _RouteRecordBase extends PathParserOptions {
  * @example
  *
  * ```ts
- * // typings.d.ts
+ * // typings.d.ts or router.ts
+ *
  * import 'vue-router';
  * declare module 'vue-router' {
  *   interface RouteMeta {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -254,8 +254,8 @@ export interface _RouteRecordBase extends PathParserOptions {
  *
  * ```ts
  * // typings.d.ts or router.ts
- *
  * import 'vue-router';
+ *
  * declare module 'vue-router' {
  *   interface RouteMeta {
  *     requiresAuth?: boolean


### PR DESCRIPTION
added to the chinese docs and also recommending a file name `typings.d.ts` to make a bit clear on where it should be placed