### PR TITLE
Fix for #873 : replce router param value which is not a string or a number with empty string

### DIFF
--- a/__tests__/encoding.spec.ts
+++ b/__tests__/encoding.spec.ts
@@ -55,6 +55,21 @@ describe('Encoding', () => {
     it('encodes a specific charset', () => {
       expect(encodeParam(toEncode)).toBe(encodedToEncode)
     })
+
+    it('encodes undefined', () => {
+      // @ts-ignore
+      expect(encodeParam(undefined)).toBe('')
+    })
+
+    it('encodes false', () => {
+      // @ts-ignore
+      expect(encodeParam(false)).toBe('')
+    })
+
+    it('encodes true', () => {
+      // @ts-ignore
+      expect(encodeParam(true)).toBe('')
+    })
   })
 
   describe('query params', () => {

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -123,9 +123,13 @@ export function encodePath(text: string | number): string {
  * slash (`/`) character.
  *
  * @param text - string to encode
- * @returns encoded string
+ * @returns encoded string or a empty sting if text is not a sting or a number
  */
 export function encodeParam(text: string | number): string {
+  const type = typeof text
+  if (type !== 'string' && type !== 'number') {
+    return ''
+  }
   return encodePath(text).replace(SLASH_RE, '%2F')
 }
 


### PR DESCRIPTION
This is a fix #873 and #855.

There may be more similar issues in the future and I think we can fix this problem by simply replace the param values with empty strings.