### PR TITLE
chore: ignore .idea/ and debug.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ markdown
 explorations
 selenium-server.log
 browserstack.err
+.idea
+debug.log


### PR DESCRIPTION
Ignore `webstorm` `.idea/` directory.
Ignore `vscode` `debug.log` file.