### PR TITLE
fix(hash): allow characters after `#` in base e.g. `#!`

### DIFF
--- a/__tests__/history/html5.spec.ts
+++ b/__tests__/history/html5.spec.ts
@@ -16,6 +16,11 @@ describe('History HTMl5', () => {
     dom = createDom()
   })
 
+  beforeEach(() => {
+    // empty the state to simulate an initial navigation by default
+    window.history.replaceState(null, '', '')
+  })
+
   afterAll(() => {
     dom.window.close()
   })
@@ -103,7 +108,14 @@ describe('History HTMl5', () => {
   describe('specific to base containing a hash', () => {
     it('calls push with hash part of the url with a base', () => {
       dom.reconfigure({ url: 'file:///usr/etc/index.html' })
+      let initialSpy = jest.spyOn(window.history, 'replaceState')
       let history = createWebHistory('#')
+      // initial navigation
+      expect(initialSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.any(String),
+        '#/'
+      )
       let spy = jest.spyOn(window.history, 'pushState')
       history.push('/foo')
       expect(spy).toHaveBeenCalledWith(
@@ -112,11 +124,19 @@ describe('History HTMl5', () => {
         '#/foo'
       )
       spy.mockRestore()
+      initialSpy.mockRestore()
     })
 
     it('works with something after the hash in the base', () => {
       dom.reconfigure({ url: 'file:///usr/etc/index.html' })
+      let initialSpy = jest.spyOn(window.history, 'replaceState')
       let history = createWebHistory('#something')
+      // initial navigation
+      expect(initialSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.any(String),
+        '#something/'
+      )
       let spy = jest.spyOn(window.history, 'pushState')
       history.push('/foo')
       expect(spy).toHaveBeenCalledWith(
@@ -125,6 +145,7 @@ describe('History HTMl5', () => {
         '#something/foo'
       )
       spy.mockRestore()
+      initialSpy.mockRestore()
     })
 
     it('works with #! and on a file with initial location', () => {
@@ -146,7 +167,7 @@ describe('History HTMl5', () => {
       expect(spy).toHaveBeenCalledWith(
         expect.anything(),
         expect.any(String),
-        '#other/foo'
+        '#other/'
       )
       spy.mockRestore()
     })
@@ -158,7 +179,7 @@ describe('History HTMl5', () => {
       expect(spy).toHaveBeenCalledWith(
         expect.anything(),
         expect.any(String),
-        '#other/foo'
+        '#other/'
       )
       spy.mockRestore()
     })

--- a/__tests__/history/html5.spec.ts
+++ b/__tests__/history/html5.spec.ts
@@ -100,55 +100,79 @@ describe('History HTMl5', () => {
     spy.mockRestore()
   })
 
-  it('calls push with hash part of the url with a base', () => {
-    dom.reconfigure({ url: 'file:///usr/etc/index.html' })
-    let history = createWebHistory('#')
-    let spy = jest.spyOn(window.history, 'pushState')
-    history.push('/foo')
-    expect(spy).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.any(String),
-      '#/foo'
-    )
-    spy.mockRestore()
-  })
+  describe('specific to base containing a hash', () => {
+    it('calls push with hash part of the url with a base', () => {
+      dom.reconfigure({ url: 'file:///usr/etc/index.html' })
+      let history = createWebHistory('#')
+      let spy = jest.spyOn(window.history, 'pushState')
+      history.push('/foo')
+      expect(spy).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.any(String),
+        '#/foo'
+      )
+      spy.mockRestore()
+    })
 
-  it('works with something after the hash in the base', () => {
-    dom.reconfigure({ url: 'file:///usr/etc/index.html' })
-    let history = createWebHistory('#something')
-    let spy = jest.spyOn(window.history, 'pushState')
-    history.push('/foo')
-    expect(spy).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.any(String),
-      '#something/foo'
-    )
-    spy.mockRestore()
-  })
+    it('works with something after the hash in the base', () => {
+      dom.reconfigure({ url: 'file:///usr/etc/index.html' })
+      let history = createWebHistory('#something')
+      let spy = jest.spyOn(window.history, 'pushState')
+      history.push('/foo')
+      expect(spy).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.any(String),
+        '#something/foo'
+      )
+      spy.mockRestore()
+    })
 
-  it('works with ! or others after the hash in the base', () => {
-    dom.reconfigure({ url: 'file:///usr/etc/index.html' })
-    let history = createWebHistory('#!')
-    let spy = jest.spyOn(window.history, 'pushState')
-    history.push('/foo')
-    expect(spy).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.any(String),
-      '#!/foo'
-    )
-    spy.mockRestore()
-  })
+    it('works with #! and on a file with initial location', () => {
+      dom.reconfigure({ url: 'file:///usr/etc/index.html#!/foo' })
+      let spy = jest.spyOn(window.history, 'replaceState')
+      createWebHistory('#!')
+      expect(spy).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.any(String),
+        '#!/foo'
+      )
+      spy.mockRestore()
+    })
 
-  it('works with  other excepting ! after the hash in the base', () => {
-    dom.reconfigure({ url: 'file:///usr/etc/index.html' })
-    let history = createWebHistory('#other')
-    let spy = jest.spyOn(window.history, 'pushState')
-    history.push('/foo')
-    expect(spy).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.any(String),
-      '#other/foo'
-    )
-    spy.mockRestore()
+    it('works with #other', () => {
+      dom.reconfigure({ url: 'file:///usr/etc/index.html' })
+      let spy = jest.spyOn(window.history, 'replaceState')
+      createWebHistory('#other')
+      expect(spy).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.any(String),
+        '#other/foo'
+      )
+      spy.mockRestore()
+    })
+
+    it('works with custom#other in domain', () => {
+      dom.reconfigure({ url: 'https://esm.dev/custom' })
+      let spy = jest.spyOn(window.history, 'replaceState')
+      createWebHistory('custom#other')
+      expect(spy).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.any(String),
+        '#other/foo'
+      )
+      spy.mockRestore()
+    })
+
+    it('works with #! and a host with initial location', () => {
+      dom.reconfigure({ url: 'https://esm.dev/#!/foo' })
+      let spy = jest.spyOn(window.history, 'replaceState')
+      createWebHistory('/#!')
+      expect(spy).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.any(String),
+        '#!/foo'
+      )
+      spy.mockRestore()
+    })
   })
 })

--- a/__tests__/history/html5.spec.ts
+++ b/__tests__/history/html5.spec.ts
@@ -32,7 +32,7 @@ describe('History HTMl5', () => {
     expect(createWebHistory('/').base).toBe('')
     expect(createWebHistory('/#').base).toBe('/#')
     expect(createWebHistory('#!').base).toBe('#!')
-    expect(createWebHistory('#a').base).toBe('#a')
+    expect(createWebHistory('#other').base).toBe('#other')
   })
 
   it('handles a base tag', () => {
@@ -72,14 +72,14 @@ describe('History HTMl5', () => {
     expect(createWebHistory('#').base).toBe('#')
     expect(createWebHistory('#/').base).toBe('#')
     expect(createWebHistory('#!/').base).toBe('#!')
-    expect(createWebHistory('#a/').base).toBe('#a')
+    expect(createWebHistory('#other/').base).toBe('#other')
   })
 
   it('handles a non-empty hash base', () => {
     expect(createWebHistory('#/bar').base).toBe('#/bar')
     expect(createWebHistory('#/bar/').base).toBe('#/bar')
     expect(createWebHistory('#!/bar/').base).toBe('#!/bar')
-    expect(createWebHistory('#a/bar/').base).toBe('#a/bar')
+    expect(createWebHistory('#other/bar/').base).toBe('#other/bar')
   })
 
   it('prepends the host to support // urls', () => {
@@ -139,15 +139,15 @@ describe('History HTMl5', () => {
     spy.mockRestore()
   })
 
-  it('works with  others excepting ! after the hash in the base', () => {
+  it('works with  other excepting ! after the hash in the base', () => {
     dom.reconfigure({ url: 'file:///usr/etc/index.html' })
-    let history = createWebHistory('#a')
+    let history = createWebHistory('#other')
     let spy = jest.spyOn(window.history, 'pushState')
     history.push('/foo')
     expect(spy).toHaveBeenCalledWith(
       expect.anything(),
       expect.any(String),
-      '#a/foo'
+      '#other/foo'
     )
     spy.mockRestore()
   })

--- a/__tests__/history/html5.spec.ts
+++ b/__tests__/history/html5.spec.ts
@@ -30,6 +30,9 @@ describe('History HTMl5', () => {
   it('handles a basic base', () => {
     expect(createWebHistory().base).toBe('')
     expect(createWebHistory('/').base).toBe('')
+    expect(createWebHistory('/#').base).toBe('/#')
+    expect(createWebHistory('#!').base).toBe('#!')
+    expect(createWebHistory('#a').base).toBe('#a')
   })
 
   it('handles a base tag', () => {
@@ -68,11 +71,15 @@ describe('History HTMl5', () => {
   it('handles a single hash base', () => {
     expect(createWebHistory('#').base).toBe('#')
     expect(createWebHistory('#/').base).toBe('#')
+    expect(createWebHistory('#!/').base).toBe('#!')
+    expect(createWebHistory('#a/').base).toBe('#a')
   })
 
   it('handles a non-empty hash base', () => {
     expect(createWebHistory('#/bar').base).toBe('#/bar')
     expect(createWebHistory('#/bar/').base).toBe('#/bar')
+    expect(createWebHistory('#!/bar/').base).toBe('#!/bar')
+    expect(createWebHistory('#a/bar/').base).toBe('#a/bar')
   })
 
   it('prepends the host to support // urls', () => {
@@ -115,6 +122,32 @@ describe('History HTMl5', () => {
       expect.anything(),
       expect.any(String),
       '#something/foo'
+    )
+    spy.mockRestore()
+  })
+
+  it('works with ! or others after the hash in the base', () => {
+    dom.reconfigure({ url: 'file:///usr/etc/index.html' })
+    let history = createWebHistory('#!')
+    let spy = jest.spyOn(window.history, 'pushState')
+    history.push('/foo')
+    expect(spy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.any(String),
+      '#!/foo'
+    )
+    spy.mockRestore()
+  })
+
+  it('works with  others excepting ! after the hash in the base', () => {
+    dom.reconfigure({ url: 'file:///usr/etc/index.html' })
+    let history = createWebHistory('#a')
+    let spy = jest.spyOn(window.history, 'pushState')
+    history.push('/foo')
+    expect(spy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.any(String),
+      '#a/foo'
     )
     spy.mockRestore()
   })

--- a/src/history/html5.ts
+++ b/src/history/html5.ts
@@ -43,11 +43,11 @@ function createCurrentLocation(
   const hashPos = base.indexOf('#')
   if (hashPos > -1) {
     let slicePos =
-      hash.indexOf(base.slice(hashPos).toLowerCase()) > -1
+      hash.includes(base.slice(hashPos))
         ? base.slice(hashPos).length
         : 1
     let pathFromHash = hash.slice(slicePos)
-
+// prepend the starting slash to hash so the url starts with /#
     if (pathFromHash[0] !== '/') pathFromHash = '/' + pathFromHash
     return stripBase(pathFromHash, '')
   }

--- a/src/history/html5.ts
+++ b/src/history/html5.ts
@@ -39,11 +39,15 @@ function createCurrentLocation(
   location: Location
 ): HistoryLocation {
   const { pathname, search, hash } = location
-  // allows hash based url
+  // allows hash based or hashbang based url or others
   const hashPos = base.indexOf('#')
   if (hashPos > -1) {
-    // prepend the starting slash to hash so the url starts with /#
-    let pathFromHash = hash.slice(1)
+    let slicePos =
+      hash.indexOf(base.slice(hashPos).toLowerCase()) > -1
+        ? base.slice(hashPos).length
+        : 1
+    let pathFromHash = hash.slice(slicePos)
+
     if (pathFromHash[0] !== '/') pathFromHash = '/' + pathFromHash
     return stripBase(pathFromHash, '')
   }

--- a/src/history/html5.ts
+++ b/src/history/html5.ts
@@ -42,12 +42,11 @@ function createCurrentLocation(
   // allows hash bases like #, /#, #/, #!, #!/, /#!/, or even /folder#end
   const hashPos = base.indexOf('#')
   if (hashPos > -1) {
-    let slicePos =
-      hash.includes(base.slice(hashPos))
-        ? base.slice(hashPos).length
-        : 1
+    let slicePos = hash.includes(base.slice(hashPos))
+      ? base.slice(hashPos).length
+      : 1
     let pathFromHash = hash.slice(slicePos)
-// prepend the starting slash to hash so the url starts with /#
+    // prepend the starting slash to hash so the url starts with /#
     if (pathFromHash[0] !== '/') pathFromHash = '/' + pathFromHash
     return stripBase(pathFromHash, '')
   }

--- a/src/history/html5.ts
+++ b/src/history/html5.ts
@@ -39,7 +39,7 @@ function createCurrentLocation(
   location: Location
 ): HistoryLocation {
   const { pathname, search, hash } = location
-  // allows hash based or hashbang based url or others
+  // allows hash bases like #, /#, #/, #!, #!/, /#!/, or even /folder#end
   const hashPos = base.indexOf('#')
   if (hashPos > -1) {
     let slicePos =


### PR DESCRIPTION
Fix #923 