### PR TITLE
Fix the lint check failure of #921

### DIFF
--- a/__tests__/hash-manual-navigation.spec.ts
+++ b/__tests__/hash-manual-navigation.spec.ts
@@ -1,0 +1,78 @@
+import { createMemoryHistory, createRouter } from '../src'
+import { tick } from './utils'
+
+const component = {}
+
+describe('hash history edge cases', () => {
+  it('correctly sets the url when it is manually changed but aborted with a redirect in guard', async () => {
+    const history = createMemoryHistory() as any
+    const router = createRouter({
+      history,
+      routes: [
+        { path: '/', component },
+        { path: '/foo', component },
+      ],
+    })
+
+    await router.push('/foo?step=1')
+    await router.push('/foo?step=2')
+    await router.push('/foo?step=3')
+    router.back()
+    await tick() // wait for router listener on history
+    expect(router.currentRoute.value.fullPath).toBe('/foo?step=2')
+
+    // force a redirect next time
+    router.beforeEach(to => {
+      if (to.path === '/') {
+        return '/foo?step=2'
+      } else {
+        return
+      }
+    })
+
+    // const spy = jest.spyOn(history, 'go')
+
+    history.changeURL('/')
+    await tick()
+    expect(router.currentRoute.value.fullPath).toBe('/foo?step=2')
+    expect(history.location).toBe('/foo?step=2')
+    // expect(spy).toHaveBeenCalledTimes(1)
+    // expect(spy).toHaveBeenCalledWith(-1)
+  })
+
+  it('correctly sets the url when it is manually changed but aborted with guard', async () => {
+    const history = createMemoryHistory() as any
+    const router = createRouter({
+      history,
+      routes: [
+        { path: '/', component },
+        { path: '/foo', component },
+      ],
+    })
+
+    await router.push('/foo?step=1')
+    await router.push('/foo?step=2')
+    await router.push('/foo?step=3')
+    router.back()
+    await tick() // wait for router listener on history
+    expect(router.currentRoute.value.fullPath).toBe('/foo?step=2')
+
+    // force a redirect next time
+    router.beforeEach(to => {
+      if (to.path === '/') {
+        return false
+      } else {
+        return
+      }
+    })
+
+    // const spy = jest.spyOn(history, 'go')
+
+    history.changeURL('/')
+    await tick()
+    expect(router.currentRoute.value.fullPath).toBe('/foo?step=2')
+    expect(history.location).toBe('/foo?step=2')
+    // expect(spy).toHaveBeenCalledTimes(1)
+    // expect(spy).toHaveBeenCalledWith(-1)
+  })
+})

--- a/src/history/memory.ts
+++ b/src/history/memory.ts
@@ -104,7 +104,7 @@ export function createMemoryHistory(base: string = ''): RouterHistory {
 
   if (__TEST__) {
     // @ts-ignore: only for tests
-    routerHistory.changeURL = function (url: string) {
+    ;(routerHistory as any).changeURL = function (url: string) {
       const from = this.location
       queue.splice(position++ + 1, queue.length, url)
       triggerListeners(this.location, from, {

--- a/src/router.ts
+++ b/src/router.ts
@@ -13,7 +13,7 @@ import {
   RouteLocationOptions,
   MatcherLocationRaw,
 } from './types'
-import { RouterHistory, HistoryState } from './history/common'
+import { RouterHistory, HistoryState, NavigationType } from './history/common'
 import {
   ScrollPosition,
   getSavedScrollPosition,
@@ -969,7 +969,24 @@ export function createRouter(options: RouterOptions): Router {
               (error as NavigationRedirectError).to,
               toLocation
               // avoid an uncaught rejection, let push call triggerError
-            ).catch(noop)
+            )
+              .then(failure => {
+                // manual change in hash history #916 ending up in the URL not
+                // changing but it was changed by the manual url change, so we
+                // need to manually change it ourselves
+                if (
+                  isNavigationFailure(
+                    failure,
+                    ErrorTypes.NAVIGATION_ABORTED |
+                      ErrorTypes.NAVIGATION_DUPLICATED
+                  ) &&
+                  !info.delta &&
+                  info.type === NavigationType.pop
+                ) {
+                  routerHistory.go(-1, false)
+                }
+              })
+              .catch(noop)
             // avoid the then branch
             return Promise.reject()
           }
@@ -989,7 +1006,21 @@ export function createRouter(options: RouterOptions): Router {
             )
 
           // revert the navigation
-          if (failure && info.delta) routerHistory.go(-info.delta, false)
+          if (failure) {
+            if (info.delta) {
+              routerHistory.go(-info.delta, false)
+            } else if (
+              info.type === NavigationType.pop &&
+              isNavigationFailure(
+                failure,
+                ErrorTypes.NAVIGATION_ABORTED | ErrorTypes.NAVIGATION_DUPLICATED
+              )
+            ) {
+              // manual change in hash history #916
+              // it's like a push but lacks the information of the direction
+              routerHistory.go(-1, false)
+            }
+          }
 
           triggerAfterEach(
             toLocation as RouteLocationNormalizedLoaded,


### PR DESCRIPTION
This PR is a fix of #921 .

The declear of `changeURL` seems doesn't work and the lint check still reports.

I think we can make the `routerHistory` to be a `any` object like this :
```javascript
(routerHistory as any).changeURL = function (url: string) {
```

WDYT?