### PR TITLE
docs: update history mode example

### DIFF
--- a/docs/guide/essentials/history-mode.md
+++ b/docs/guide/essentials/history-mode.md
@@ -76,9 +76,9 @@ const httpPort = 80
 
 http
   .createServer((req, res) => {
-    fs.readFile('index.htm', 'utf-8', (err, content) => {
+    fs.readFile('index.html', 'utf-8', (err, content) => {
       if (err) {
-        console.log('We cannot open "index.htm" file.')
+        console.log('We cannot open "index.html" file.')
       }
 
       res.writeHead(200, {
@@ -122,7 +122,13 @@ For Node.js/Express, consider using [connect-history-api-fallback middleware](ht
 </configuration>
 ```
 
-### Caddy
+### Caddy v2
+
+```
+try_files {path} /
+```
+
+### Caddy v1
 
 ```
 rewrite {

--- a/docs/zh/guide/essentials/history-mode.md
+++ b/docs/zh/guide/essentials/history-mode.md
@@ -76,9 +76,9 @@ const httpPort = 80
 
 http
   .createServer((req, res) => {
-    fs.readFile('index.htm', 'utf-8', (err, content) => {
+    fs.readFile('index.html', 'utf-8', (err, content) => {
       if (err) {
-        console.log('We cannot open "index.htm" file.')
+        console.log('We cannot open "index.html" file.')
       }
 
       res.writeHead(200, {
@@ -122,7 +122,13 @@ http
 </configuration>
 ```
 
-### Caddy
+### Caddy v2
+
+```
+try_files {path} /
+```
+
+### Caddy v1
 
 ```
 rewrite {


### PR DESCRIPTION
1. Fix some typos.
2. Update `history-mode.md`, add an example that will work for Caddy v2.