### PR TITLE
docs: add scrollBehavior API detail and link to guide

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -746,12 +746,14 @@ routes: RouteRecordRaw[]
 
 ### scrollBehavior
 
-Function to control scrolling when navigating between pages. Can return a Promise to delay scrolling. Check .
+Function to control scrolling when navigating between pages. Can return a ScrollPosition object or a Promise to delay scrolling.
+  
+See [Scroll Behaviour](../guide/advanced/scroll-behavior.md) for more details.
 
 **Signature:**
 
 ```typescript
-scrollBehavior?: ScrollBehavior
+scrollBehavior?: RouterScrollBehavior
 ```
 
 #### Examples

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -746,9 +746,7 @@ routes: RouteRecordRaw[]
 
 ### scrollBehavior
 
-Function to control scrolling when navigating between pages. Can return a ScrollPosition object or a Promise to delay scrolling.
-  
-See [Scroll Behaviour](../guide/advanced/scroll-behavior.md) for more details.
+Function to control scrolling when navigating between pages. Can return a Promise to delay when the scrolling happens. See [Scroll Behaviour](../guide/advanced/scroll-behavior.md) for more details.
 
 **Signature:**
 


### PR DESCRIPTION
Fixes #953 

Add a bit more detail to the `scrollBehavior` API docs, and most importantly link to the very comprehensive guide.