### PR TITLE
docs: note about new props when using props: true

### DIFF
--- a/docs/guide/essentials/passing-props.md
+++ b/docs/guide/essentials/passing-props.md
@@ -15,6 +15,7 @@ with
 
 ```js
 const User = {
+  // prop names must match route params for values to be passed
   props: ['id'],
   template: '<div>User {{ id }}</div>'
 }
@@ -22,8 +23,6 @@ const routes = [{ path: '/user/:id', component: User, props: true }]
 ```
 
 This allows you to use the component anywhere, which makes the component easier to reuse and test.
-
-Note that you must name your props to match their respective route params (without the `:` prefix) in order for the values to be passed.
 
 ## Boolean mode
 

--- a/docs/guide/essentials/passing-props.md
+++ b/docs/guide/essentials/passing-props.md
@@ -23,6 +23,8 @@ const routes = [{ path: '/user/:id', component: User, props: true }]
 
 This allows you to use the component anywhere, which makes the component easier to reuse and test.
 
+Note that you must name your props to match their respective route params (without the `:` prefix) in order for the values to be passed.
+
 ## Boolean mode
 
 When `props` is set to `true`, the `route.params` will be set as the component props.

--- a/docs/guide/essentials/passing-props.md
+++ b/docs/guide/essentials/passing-props.md
@@ -15,7 +15,7 @@ with
 
 ```js
 const User = {
-  // prop names must match route params for values to be passed
+  // make sure to add a prop named exactly like the route param
   props: ['id'],
   template: '<div>User {{ id }}</div>'
 }


### PR DESCRIPTION
Highlighted the fact that in order for `props: true` to work, you need to explicitly define those props and name them correctly for the values to pass.