### PR TITLE
chore(playground): unused '@ts-expect-error' directive

### DIFF
--- a/playground/main.ts
+++ b/playground/main.ts
@@ -10,7 +10,6 @@ declare global {
     // h: HTML5History
     h: typeof routerHistory
     r: typeof router
-    // @ts-expect-error
     vm: ComponentPublicInstance
   }
 }


### PR DESCRIPTION
There is a error when run command `yarn dev`:
```
./playground/main.ts 13:4-23
[tsl] ERROR in D:\github\vuejs\vue-router-next\playground\main.ts(13,5)
      TS2578: Unused '@ts-expect-error' directive.
```
I think we should remove the comment `// @ts-expect-error` in `playground/main.ts`.