### PR TITLE
docs: removal of fallback option

### DIFF
--- a/docs/guide/migration/index.md
+++ b/docs/guide/migration/index.md
@@ -67,6 +67,20 @@ createRouter({
 })
 ```
 
+### Removal of the `fallback` option
+
+The `fallback` option is no longer supported when creating the router:
+
+```diff
+-new VueRouter({
++createRouter({
+-  fallback: false,
+// other options...
+})
+```
+
+**Reason**: All browser supported by Vue support the [HTML5 History API](https://developer.mozilla.org/en-US/docs/Web/API/History_API), allowing us to avoid hacks around modifying `location.hash` and directly use `history.pushState()`.
+
 ### Removed `*` (star or catch all) routes
 
 Catch all routes (`*`, `/*`) must now be defined using a parameter with a custom regex:

--- a/docs/guide/migration/index.md
+++ b/docs/guide/migration/index.md
@@ -79,7 +79,7 @@ The `fallback` option is no longer supported when creating the router:
 })
 ```
 
-**Reason**: All browser supported by Vue support the [HTML5 History API](https://developer.mozilla.org/en-US/docs/Web/API/History_API), allowing us to avoid hacks around modifying `location.hash` and directly use `history.pushState()`.
+**Reason**: All browsers supported by Vue support the [HTML5 History API](https://developer.mozilla.org/en-US/docs/Web/API/History_API), allowing us to avoid hacks around modifying `location.hash` and directly use `history.pushState()`.
 
 ### Removed `*` (star or catch all) routes
 

--- a/docs/zh/guide/migration/index.md
+++ b/docs/zh/guide/migration/index.md
@@ -67,6 +67,20 @@ createRouter({
 })
 ```
 
+### 删除了 `RouterOptions` 中的 `fallback` 属性
+
+创建路由器时不再支持 `fallback` 选项：
+
+```diff
+-new VueRouter({
++createRouter({
+-  fallback: false,
+// other options...
+})
+```
+
+**原因**: Vue支持的所有浏览器都支持 [HTML5 History API](https://developer.mozilla.org/zh-CN/docs/Web/API/History_API)，因此我们不再需要使用 `location.hash`，而可以直接使用 `history.pushState()`。
+
 ### 删除了 `*`（星标或通配符）路由
 
 现在必须使用自定义的 regex 参数来定义所有路由(`*`、`/*`)：

--- a/docs/zh/guide/migration/index.md
+++ b/docs/zh/guide/migration/index.md
@@ -69,7 +69,7 @@ createRouter({
 
 ### 删除了 `RouterOptions` 中的 `fallback` 属性
 
-创建路由器时不再支持 `fallback` 选项：
+创建路由时不再支持 `fallback` 属性：
 
 ```diff
 -new VueRouter({


### PR DESCRIPTION
The `fallback` option has been removed now but not documented in `migration` docs.

I didn't add the `reason` of it, cause I'm not sure about the reason of the removal.

IMO, the reason of the removal of `fallback` is that the modern browsers all support `history.pushState` - except for IE, which is not supported by Vue 3.0. So we do not need a `fallback` option here. Am I right about this?

I can add the `reason` afterwards if needed.