### PR TITLE
feat(link): expose useLink on RouterLink as internal

### DIFF
--- a/src/RouterLink.ts
+++ b/src/RouterLink.ts
@@ -149,6 +149,8 @@ export const RouterLinkImpl = /*#__PURE__*/ defineComponent({
     },
   },
 
+  useLink,
+
   setup(props, { slots }) {
     const link = reactive(useLink(props))
     const { options } = inject(routerKey)!
@@ -213,8 +215,6 @@ export const RouterLinkImpl = /*#__PURE__*/ defineComponent({
   },
 })
 
-RouterLinkImpl.useLink = useLink
-
 // export the public type for h/tsx inference
 // also to avoid inline import() in generated d.ts files
 /**
@@ -227,6 +227,12 @@ export const RouterLink = RouterLinkImpl as unknown as {
       VNodeProps &
       RouterLinkProps
   }
+
+  /**
+   * Access to `useLink()` without depending on using vue-router
+   *
+   * @internal
+   */
   useLink: typeof useLink
 }
 

--- a/src/RouterLink.ts
+++ b/src/RouterLink.ts
@@ -213,18 +213,21 @@ export const RouterLinkImpl = /*#__PURE__*/ defineComponent({
   },
 })
 
+RouterLinkImpl.useLink = useLink
+
 // export the public type for h/tsx inference
 // also to avoid inline import() in generated d.ts files
 /**
  * Component to render a link that triggers a navigation on click.
  */
-export const RouterLink = RouterLinkImpl as {
+export const RouterLink = RouterLinkImpl as unknown as {
   new (): {
     $props: AllowedComponentProps &
       ComponentCustomProps &
       VNodeProps &
       RouterLinkProps
   }
+  useLink: typeof useLink
 }
 
 function guardEvent(e: MouseEvent) {


### PR DESCRIPTION
This allows us to make vue-router optional while still being able to use the composable instead of router-link itself:
```ts
import { resolveDynamicComponent } from 'vue'
import type {
  RouterLink as _RouterLink,
  useLink as _useLink,
  UseLinkOptions,
} from 'vue-router'

function useLink (props: Partial<UseLinkOptions>): ReturnType<typeof _useLink> | undefined {
  const RouterLink = resolveDynamicComponent('RouterLink') as typeof _RouterLink | string

  if (typeof RouterLink === 'string') return

  const link = RouterLink.useLink(props as UseLinkOptions)

  return props.to
    ? link
    : undefined
}
```