### PR TITLE
fix(guards): components guards in mixins

### DIFF
--- a/__tests__/guards/extractComponentsGuards.spec.ts
+++ b/__tests__/guards/extractComponentsGuards.spec.ts
@@ -54,6 +54,7 @@ async function checkGuards(
     // type is fine as we excluded RouteRecordRedirect in components argument
     components.map(normalizeRouteRecord) as RouteRecordNormalized[],
     'beforeRouteEnter',
+    new Set(),
     to,
     from
   )

--- a/src/router.ts
+++ b/src/router.ts
@@ -352,6 +352,7 @@ export interface Router {
  * @param options - {@link RouterOptions}
  */
 export function createRouter(options: RouterOptions): Router {
+  const installedApps = new Set<App>()
   const matcher = createRouterMatcher(options.routes, options)
   let parseQuery = options.parseQuery || originalParseQuery
   let stringifyQuery = options.stringifyQuery || originalStringifyQuery
@@ -761,6 +762,7 @@ export function createRouter(options: RouterOptions): Router {
     guards = extractComponentsGuards(
       leavingRecords.reverse(),
       'beforeRouteLeave',
+      installedApps,
       to,
       from
     )
@@ -798,6 +800,7 @@ export function createRouter(options: RouterOptions): Router {
           guards = extractComponentsGuards(
             updatingRecords,
             'beforeRouteUpdate',
+            installedApps,
             to,
             from
           )
@@ -841,6 +844,7 @@ export function createRouter(options: RouterOptions): Router {
           guards = extractComponentsGuards(
             enteringRecords,
             'beforeRouteEnter',
+            installedApps,
             to,
             from
           )
@@ -1124,7 +1128,6 @@ export function createRouter(options: RouterOptions): Router {
   const go = (delta: number) => routerHistory.go(delta)
 
   let started: boolean | undefined
-  const installedApps = new Set<App>()
 
   const router: Router = {
     currentRoute,

--- a/src/router.ts
+++ b/src/router.ts
@@ -1214,10 +1214,10 @@ export function createRouter(options: RouterOptions): Router {
 }
 
 function runGuardQueue(guards: Lazy<any>[]): Promise<void> {
-  return guards.reduce(
-    (promise, guard) => promise.then(() => guard()),
-    Promise.resolve()
-  )
+  return guards.reduce((promise, guard) => {
+    const promises = Array.isArray(promise) ? promise : [promise]
+    return Promise.all(promises).then(() => guard())
+  }, Promise.resolve())
 }
 
 function extractChangingRecords(

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,7 +5,7 @@ import { RouteRecord, RouteRecordNormalized } from '../matcher/types'
 import { HistoryState } from '../history/common'
 import { NavigationFailure } from '../errors'
 
-export type Lazy<T> = () => Promise<T>
+export type Lazy<T> = () => Promise<T> | Promise<Array<Promise<T>>>
 export type Override<T, U> = Pick<T, Exclude<keyof T, keyof U>> & U
 
 // TODO: find a better way to type readonly types. Readonly<T> is non recursive, maybe we should use it at multiple places. It would also allow preventing the problem Immutable create.


### PR DESCRIPTION
https://github.com/vuejs/vue-router-next/issues/454
Maybe not a good idea, but since you are using rawComponent it makes sense.
Probably it was worth on the vue side to create the ability to resolve component options, just as it exists for an instance.

As written here:
https://github.com/vuejs/vue-next/issues/2119
