### PR TITLE
fix(types): Support `undefined` in NavigationGuardNext 

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -367,7 +367,6 @@ export interface MatcherLocation
   > {}
 
 export interface NavigationGuardNext {
-  (): void
   (error: Error): void
   (location?: RouteLocationRaw): void
   (valid: boolean): void

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -369,7 +369,7 @@ export interface MatcherLocation
 export interface NavigationGuardNext {
   (): void
   (error: Error): void
-  (location: RouteLocationRaw): void
+  (location?: RouteLocationRaw): void
   (valid: boolean): void
   (cb: NavigationGuardNextCallback): void
   /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -369,8 +369,8 @@ export interface MatcherLocation
 export interface NavigationGuardNext {
   (): void
   (error: Error): void
-  (location?: RouteLocationRaw): void
-  (valid: boolean): void
+  (location: RouteLocationRaw): void
+  (valid: boolean | undefined): void
   (cb: NavigationGuardNextCallback): void
   /**
    * Allows to detect if `next` isn't called in a resolved guard. Used

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -367,6 +367,7 @@ export interface MatcherLocation
   > {}
 
 export interface NavigationGuardNext {
+  (): void
   (error: Error): void
   (location?: RouteLocationRaw): void
   (valid: boolean): void

--- a/test-dts/navigationGuards.test-d.ts
+++ b/test-dts/navigationGuards.test-d.ts
@@ -26,6 +26,10 @@ router.beforeEach((to, from) => {
   return false
 })
 
+router.beforeEach((to, from, next) => {
+  next(undefined)
+})
+
 // @ts-expect-error
 router.beforeEach((to, from, next) => {
   return Symbol('not supported')


### PR DESCRIPTION
Add support for `undefined` as the first argument in `next` function in navigation guards. I've decided to do it through making `location` argument optional since it seems to me as using `undefined` is omitting redefining the next route location.

Related to: https://github.com/vuejs/vue-router-next/issues/1058