### PR TITLE
fix(ssr): memory leak, only track installedApps in browser

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -1201,20 +1201,22 @@ export function createRouter(options: RouterOptions): Router {
       app.provide(routeLocationKey, reactive(reactiveRoute))
       app.provide(routerViewLocationKey, currentRoute)
 
-      const unmountApp = app.unmount
-      installedApps.add(app)
-      app.unmount = function () {
-        installedApps.delete(app)
-        // the router is not attached to an app anymore
-        if (installedApps.size < 1) {
-          // invalidate the current navigation
-          pendingLocation = START_LOCATION_NORMALIZED
-          removeHistoryListener && removeHistoryListener()
-          currentRoute.value = START_LOCATION_NORMALIZED
-          started = false
-          ready = false
+      if (isBrowser) {
+        const unmountApp = app.unmount
+        installedApps.add(app)
+        app.unmount = function () {
+          installedApps.delete(app)
+          // the router is not attached to an app anymore
+          if (installedApps.size < 1) {
+            // invalidate the current navigation
+            pendingLocation = START_LOCATION_NORMALIZED
+            removeHistoryListener && removeHistoryListener()
+            currentRoute.value = START_LOCATION_NORMALIZED
+            started = false
+            ready = false
+          }
+          unmountApp()
         }
-        unmountApp()
       }
 
       if ((__DEV__ || __FEATURE_PROD_DEVTOOLS__) && isBrowser) {


### PR DESCRIPTION
Could there be cases where some does want to mount + unmount on server side? An alternative could be to return the cleanup function so it can be called manually in environments were apps are created and disposed of? Seems like more of an edge case...

EDIT: or should we be unmounting once render is complete? that is not in docs or the examples... let me see about that.