### PR TITLE
fix(history): ensure base is normalized in memory history

### DIFF
--- a/__tests__/history/memory.spec.ts
+++ b/__tests__/history/memory.spec.ts
@@ -185,4 +185,9 @@ describe('Memory history', () => {
     history.go(1, false)
     expect(spy).not.toHaveBeenCalled()
   })
+
+  it('handles a non-empty base', () => {
+    expect(createMemoryHistory('/foo/').base).toBe('/foo')
+    expect(createMemoryHistory('/foo').base).toBe('/foo')
+  })
 })

--- a/src/history/memory.ts
+++ b/src/history/memory.ts
@@ -6,6 +6,7 @@ import {
   NavigationType,
   NavigationDirection,
   NavigationInformation,
+  normalizeBase,
   createHref,
   HistoryLocation,
 } from './common'
@@ -21,6 +22,7 @@ export function createMemoryHistory(base: string = ''): RouterHistory {
   let listeners: NavigationCallback[] = []
   let queue: HistoryLocation[] = [START]
   let position: number = 0
+  base = normalizeBase(base)
 
   function setLocation(location: HistoryLocation) {
     position++


### PR DESCRIPTION
Ensure base is normalized in memory history.

When using memory history with slash-trailing base (e.g. `/foo/`), `router.resolve().href` will combine base and normalized location (e.g. `/bar/`) directly, this will cause double-slashes in href url.
To fix this issue, ensure base is normalized just like we have done in html5/hash history.