### PR TITLE
Docs: Update Vue School BTS 21 banner

### DIFF
--- a/docs/.vitepress/components/BannerTop.vue
+++ b/docs/.vitepress/components/BannerTop.vue
@@ -11,10 +11,7 @@
         <img src="/images/vueschool/vs-backpack.png" alt="Backpack">
       </div>
       <div class="vs-slogan">
-        3-months Vue School for only $49 <span style="text-decoration: line-through">$75</span>!
-        <span class="vs-slogan-light">
-          Limited Time Offer
-        </span>
+        Less than <span class="vs-slogan-light">48 hours</span> left for the Vue School offer
       </div>
       <div class="vs-button">
         GET ACCESS


### PR DESCRIPTION
This PR changes the banner on top of next.router.vuejs.org to inform visitors that it's less than 48 hours before the BTS sale expires.

Please merge this Monday, 2021-10-04.

![Screenshot 2021-10-04 at 09-58-54 Home Vue Router](https://user-images.githubusercontent.com/3766839/135855612-69f14903-6f1b-4cdd-8c6a-cd10d651e26b.png)
