### PR TITLE
Fix qs example [ci skip]

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -152,7 +152,7 @@ export interface RouterOptions extends PathParserOptions {
    *
    * createRouter({
    *   // other options...
-   *   parse: qs.parse,
+   *   parseQuery: qs.parse,
    *   stringifyQuery: qs.stringify,
    * })
    * ```


### PR DESCRIPTION
Currently referencing the non-existant `parse` property instead of `parseQuery`