### PR TITLE
chore: fix incorrect jsdoc links [skip ci]

### DIFF
--- a/src/matcher/types.ts
+++ b/src/matcher/types.ts
@@ -9,7 +9,7 @@ import { ComponentPublicInstance } from 'vue'
 
 // normalize component/components into components and make every property always present
 /**
- * Normalized version of a {@link RouteRecord | Route Record}
+ * Normalized version of a {@link RouteRecord route record}
  */
 export interface RouteRecordNormalized {
   /**

--- a/src/router.ts
+++ b/src/router.ts
@@ -198,14 +198,14 @@ export interface Router {
   readonly options: RouterOptions
 
   /**
-   * Add a new {@link RouteRecordRaw | Route Record} as the child of an existing route.
+   * Add a new {@link RouteRecordRaw route record} as the child of an existing route.
    *
    * @param parentName - Parent Route Record where `route` should be appended at
    * @param route - Route Record to add
    */
   addRoute(parentName: RouteRecordName, route: RouteRecordRaw): () => void
   /**
-   * Add a new {@link RouteRecordRaw | route record} to the router.
+   * Add a new {@link RouteRecordRaw route record} to the router.
    *
    * @param route - Route Record to add
    */
@@ -223,13 +223,13 @@ export interface Router {
    */
   hasRoute(name: RouteRecordName): boolean
   /**
-   * Get a full list of all the {@link RouteRecord | route records}.
+   * Get a full list of all the {@link RouteRecord route records}.
    */
   getRoutes(): RouteRecord[]
 
   /**
-   * Returns the {@link RouteLocation | normalized version} of a
-   * {@link RouteLocationRaw | route location}. Also includes an `href` property
+   * Returns the {@link RouteLocation normalized version} of a
+   * {@link RouteLocationRaw route location}. Also includes an `href` property
    * that includes any existing `base`. By default the `currentLocation` used is
    * `route.currentRoute` and should only be overriden in advanced use cases.
    *


### PR DESCRIPTION
removed redundant `|`s

![image](https://user-images.githubusercontent.com/33423008/139689198-208f3ba8-21a9-4369-bb0c-c3e657a02470.png)
