### PR TITLE
docs: better example

### DIFF
--- a/docs/guide/essentials/redirect-and-alias.md
+++ b/docs/guide/essentials/redirect-and-alias.md
@@ -2,7 +2,7 @@
 
 ## Redirect
 
-Redirecting is also done in the `routes` configuration. To redirect from `/a` to `/b`:
+Redirecting is also done in the `routes` configuration. To redirect from `/home` to `/`:
 
 ```js
 const routes = [{ path: '/home', redirect: '/' }]


### PR DESCRIPTION
I found that I had to re-read this section a couple of times, to figure out which was `a` and which was `b`. It would be easier to understand if the text reflected the example.