### PR TITLE
Docs: Update Vue School Black Friday banner animation

### DIFF
--- a/docs/.vitepress/components/VueSchool/BannerCoins.vue
+++ b/docs/.vitepress/components/VueSchool/BannerCoins.vue
@@ -92,9 +92,7 @@ export default {
   .vs-blackfriday-coin {
     display: inline-block;
     position: absolute;
-    transition-property: transform;
-    transition-timing-function: cubic-bezier(.17, .84, .44,1);
-    transition-duration: 75ms;
+    transition: transform 1000ms linear;
     transform: translateX(0);
   }
 


### PR DESCRIPTION
This PR updates the animation of the background coins of the Vue School Black Friday banner.

Related to [1198](https://github.com/vuejs/vue-router-next/pull/1198)