### PR TITLE
fix: push method executes both pushState and replaceState (fix: #1209)

### DIFF
--- a/src/history/html5.ts
+++ b/src/history/html5.ts
@@ -280,8 +280,6 @@ function useHistoryStateNavigation(base: string) {
       )
     }
 
-    changeLocation(currentState.current, currentState, true)
-
     const state: StateEntry = assign(
       {},
       buildState(currentLocation.value, to, null),


### PR DESCRIPTION
原问题如下：https://github.com/vuejs/vue-router-next/issues/1209，
在 `push` 方法中调用了两次 `changeLocation` 方法，其中第一次执行的时候并不会导致页面的 history url 发生变化，因为它跳转的地方是当前路径，同时它是 replace 的，这说明这个方法的作用并不是为了修改路由地址。这个操作在对使用者来说并没有功能性的错误，但是这对想要监控页面路由发生变化时带来的麻烦是巨大的。