### PR TITLE
docs: add explicit import

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -44,6 +44,8 @@ Note how instead of using regular `a` tags, we use a custom component `router-li
 ## JavaScript
 
 ```js
+import * as VueRouter from 'vue-router'
+
 // 1. Define route components.
 // These can be imported from other files
 const Home = { template: '<div>Home</div>' }


### PR DESCRIPTION
The syntax used to be `import VueRouter from 'vue-router'`, but this does not seem to work anymore. With some experimentation this seems to be the required syntax, but I can't find the documentation for that anywhere. With this change it will be clear from the code snippet how to properly import the router.