### PR TITLE
Docs: Remove Vue School's Black Friday banner

### DIFF
--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -1,8 +1,5 @@
 <template>
-  <div
-    class="main-container"
-    :class="{ 'has-top-banner': showTopBanner }"
-  >
+  <div class="main-container">
     <BannerTop
       v-if="showTopBanner"
       @close="closeBannerTop"
@@ -48,27 +45,14 @@ import { defineAsyncComponent } from 'vue'
 import DefaultTheme from 'vitepress/dist/client/theme-default'
 import sponsors from '../components/sponsors.json'
 
-const BannerTop = defineAsyncComponent(() => import('../components/VueSchool/BannerTop.vue'))
-
 export default {
   name: 'Layout',
   components: {
-    ParentLayout: DefaultTheme.Layout,
-    BannerTop
+    ParentLayout: DefaultTheme.Layout
   },
   data() {
     return {
-      sponsors,
-      showTopBanner: false
-    }
-  },
-  mounted () {
-    this.showTopBanner = !localStorage.getItem('VS_BF21_BANNER_CLOSED')
-  },
-  methods: {
-    closeBannerTop () {
-      this.showTopBanner = false
-      localStorage.setItem('VS_BF21_BANNER_CLOSED', 1)
+      sponsors
     }
   }
 }


### PR DESCRIPTION
This PR removes the Vue School Black Friday banner introduced in https://github.com/vuejs/vue-router-next/pull/1198

Please merge this **Friday Dec 10th**.

The landing page will keep working after the promo ends, so the link (https://vueschool.io/sales/blackfriday?friend=vuerouter) will still be valid.